### PR TITLE
fix: `inputs.FOO.follows = "bar";`

### DIFF
--- a/patcher.py
+++ b/patcher.py
@@ -104,7 +104,7 @@ def main(argv):
   # not transitive inputs
   rootkey = locks['root']
   for k in locks['nodes'][rootkey]['inputs'].keys():
-    v = locks['nodes'][k]
+    v = locks['nodes'].get(k, {})
     original = v.get('original')
     locked = v.get('locked')
     # log(locked)


### PR DESCRIPTION
For flake inputs that simply follow another input there is following error:

```
Traceback (most recent call last):
  File "/nix/store/ysvrk2s6s6m8glm5zy9hw30w39x8rzd2-nix-patcher-0.1.0/bin/.nix-patcher-wrapped", line 195, in <module>
    sys.exit(main(sys.argv))
             ^^^^^^^^^^^^^^
  File "/nix/store/ysvrk2s6s6m8glm5zy9hw30w39x8rzd2-nix-patcher-0.1.0/bin/.nix-patcher-wrapped", line 107, in main
    v = locks['nodes'][k]
        ~~~~~~~~~~~~~~^^^
KeyError: 'nixlib'
```